### PR TITLE
Extract subscriber number into local variable

### DIFF
--- a/kuma/javascript/src/payments/thank-you.jsx
+++ b/kuma/javascript/src/payments/thank-you.jsx
@@ -19,6 +19,7 @@ export const subheaderTitle = 'Thank you for becoming a monthly supporter!';
 export default function ThankYouPage() {
     const locale = getLocale();
     const userData = useContext(UserProvider.context);
+    const subscriberNumber = userData ? userData.subscriberNumber : null;
 
     return (
         <>
@@ -28,10 +29,10 @@ export default function ThankYouPage() {
                 <SubHeader
                     title={subheaderTitle}
                     subtitle={
-                        userData && !!userData.subscriberNumber
+                        subscriberNumber
                             ? interpolate(
                                   gettext('You are MDN member number: %s'),
-                                  [userData.subscriberNumber.toLocaleString()]
+                                  [subscriberNumber.toLocaleString()]
                               )
                             : ''
                     }


### PR DESCRIPTION
Hm I don't think flow should be failing here, I've also tried upgrading it but unfortunately to no avail. So I made things more explicit, i.e.:

https://github.com/peterbe/kuma/blob/723af5aef31ebffbf3412f8bfb57d729f525dc44/kuma/javascript/src/payments/thank-you.jsx#L31-L36
What's happening is that the `gettext` (L33) call is triggering a [type refinement invalidation](https://flow.org/en/docs/lang/refinements/#toc-refinement-invalidations), aka the type refinement you did on L31 is forgotten, because `gettext` _could_ do arbitrary things to `userData` in the meanwhile. But it doesn't and flow should know that!

In this [example](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVMCmAXMA7MAXjAFkBDbACwDoAnMvAEzgFsAKASjAD4wAGagFYwAfjAAmAMxgAXPgCuMGAG50UeXgDG2AJZwCAZ1Y5KOvAHMAKpQokd5ytgASZAG6YAyjsaYAolChMbQNOMABvVDAwHSgwNnIqOgZmdi5eAUEuMKioyJyCYjxFFTyAX1Ry1ABCKoIAMjqwAG0jFhMzKxtsOwdnN09vPwCg7BCOABp8amw4ABk4TTIsD2xaDs4AXVUgA) if you comment out L7, flow stops complaining because it knows which shared state gets touched and which doesn't. So why doesn't this work for `gettext`?

I'll do some more digging, but in the meanwhile this PR does the trick (at the cost of adding noise).